### PR TITLE
Add additional edge case testing

### DIFF
--- a/suite/api_test.rb
+++ b/suite/api_test.rb
@@ -5,7 +5,6 @@ require 'minitest/autorun'
 class ApiTest < Minitest::Test
 
   def test_no_api_key
-    skip
     make_request('?s=star', 'http://www.omdbapi.com/')
     puts last_response.body
     parse_last_response_body = JSON.parse(last_response.body)
@@ -16,12 +15,12 @@ class ApiTest < Minitest::Test
     # expect correct error status code
     assert_equal last_response.status, 401
     assert_equal parse_last_response_body.key?('Response'), true
+    assert_equal parse_last_response_body['Response'], 'False'
     assert_equal parse_last_response_body.key?('Error'), true
     assert_equal parse_last_response_body['Error'], 'No API key provided.'
   end
 
-  def test_successful_response_for_thomas
-    skip
+  def test_successful_response_for_search_of_thomas
     make_request("?apikey=#{ENV['OMDB_API_KEY']}&s=thomas", 'http://www.omdbapi.com/')
     parse_last_response_body = JSON.parse(last_response.body)
     search_results =  parse_last_response_body['Search']
@@ -46,32 +45,20 @@ class ApiTest < Minitest::Test
     end
   end
 
-  def test_i_parameter_is_accessable_by_imbdID
-    skip
-    make_request("?apikey=#{ENV['OMDB_API_KEY']}&s=thomas&page=1", 'http://www.omdbapi.com/')
+  def test_using_i_param_page_1_is_accessable_on_imbd
+    make_request("?apikey=#{ENV['OMDB_API_KEY']}&s=thomas", 'http://www.omdbapi.com/')
     parse_last_response_body = JSON.parse(last_response.body)
     search_results =  parse_last_response_body['Search']
+
     search_results.each do |result|
-      verify_id = result['imdbID'].split(//)
-      assert_equal verify_id.length, 9
-      assert_equal verify_id[0], 't'
-      assert_equal verify_id[1], 't'
-      # verifies that the trailing int's are actual int's
-      assert_equal verify_id[2].to_i.to_s, verify_id[2]
-      assert_equal verify_id[3].to_i.to_s, verify_id[3]
-      assert_equal verify_id[4].to_i.to_s, verify_id[4]
-      assert_equal verify_id[5].to_i.to_s, verify_id[5]
-      assert_equal verify_id[6].to_i.to_s, verify_id[6]
-      assert_equal verify_id[7].to_i.to_s, verify_id[7]
-      assert_equal verify_id[8].to_i.to_s, verify_id[8]
-      # verifies leading t's, that convert to a 0, are not equal
-      refute_match verify_id[0].to_i.to_s, verify_id[0]
-      refute_match verify_id[1].to_i.to_s, verify_id[1]
+      id = result['imdbID']
+      make_request("?apikey=#{ENV['OMDB_API_KEY']}&i=#{id}", 'http://www.omdbapi.com/')
+      assert_equal last_response.status, 200
     end
+
   end
 
   def test_poster_link_validity_page_1
-    skip
     make_request("?apikey=#{ENV['OMDB_API_KEY']}&s=thomas&page=1", 'http://www.omdbapi.com/')
     parse_last_response_body = JSON.parse(last_response.body)
     search_results =  parse_last_response_body['Search']
@@ -82,7 +69,7 @@ class ApiTest < Minitest::Test
   end
 
   def test_invalid_poster_links_are_okay_on_page_3
-    skip
+    # additonal edge case for invalid poster links
     make_request("?apikey=#{ENV['OMDB_API_KEY']}&s=thomas&page=3", 'http://www.omdbapi.com/')
     parse_last_response_body = JSON.parse(last_response.body)
     search_results =  parse_last_response_body['Search']
@@ -106,13 +93,123 @@ class ApiTest < Minitest::Test
         all_results << search_results
         acc += 1
       end
-      
       all_results.flatten!
+
       imbdIDs = all_results.map do |result|
         result["imdbID"]
       end
 
       assert_equal imbdIDs.length, 50
       assert_equal imbdIDs.length, imbdIDs.uniq.length
+  end
+
+# additional testing I am curious about
+  def test_imbdID_is_uniform_for_all_responses_page_1
+    make_request("?apikey=#{ENV['OMDB_API_KEY']}&s=thomas&page=1", 'http://www.omdbapi.com/')
+    parse_last_response_body = JSON.parse(last_response.body)
+    search_results =  parse_last_response_body['Search']
+    search_results.each do |result|
+      verify_id = result['imdbID'].split(//)
+      assert_equal verify_id.length, 9
+      assert_equal verify_id[0], 't'
+      assert_equal verify_id[1], 't'
+      # verifies that the trailing int's are actual int's
+      assert_equal verify_id[2].to_i.to_s, verify_id[2]
+      assert_equal verify_id[3].to_i.to_s, verify_id[3]
+      assert_equal verify_id[4].to_i.to_s, verify_id[4]
+      assert_equal verify_id[5].to_i.to_s, verify_id[5]
+      assert_equal verify_id[6].to_i.to_s, verify_id[6]
+      assert_equal verify_id[7].to_i.to_s, verify_id[7]
+      assert_equal verify_id[8].to_i.to_s, verify_id[8]
+      # verifies leading t's, that convert to INT 0, are not equal
+      refute_match verify_id[0].to_i.to_s, verify_id[0]
+      refute_match verify_id[1].to_i.to_s, verify_id[1]
+    end
+  end
+
+  def test_passing_no_query_params_throws_error
+    make_request("?apikey=#{ENV['OMDB_API_KEY']}", 'http://www.omdbapi.com/')
+    parse_last_response_body = JSON.parse(last_response.body)
+
+    assert_equal parse_last_response_body.key?('Response'), true
+    assert_equal parse_last_response_body.key?('Error'), true
+    assert_equal parse_last_response_body['Error'], 'Incorrect IMDb ID.'
+  end
+
+  def test_no_search_params_passed_throws_error
+    make_request("?apikey=#{ENV['OMDB_API_KEY']}&s=", 'http://www.omdbapi.com/')
+    parse_last_response_body = JSON.parse(last_response.body)
+
+    assert_equal parse_last_response_body.key?('Response'), true
+    assert_equal parse_last_response_body.key?('Error'), true
+    assert_equal parse_last_response_body['Error'], 'Incorrect IMDb ID.'
+  end
+
+  def test_total_results_key_exists_on_succcessful_response
+    make_request("?apikey=#{ENV['OMDB_API_KEY']}&s=thomas", 'http://www.omdbapi.com/')
+    parse_last_response_body = JSON.parse(last_response.body)
+
+    assert_equal parse_last_response_body.key?('totalResults'), true
+  end
+
+  def test_incorrect_datatypes_in_search_throws_error
+    # This is sending a 200 response. I would probably ask that a differnt code be
+    # sent instead of 200 for an error
+    make_request("?apikey=#{ENV['OMDB_API_KEY']}&s=#{12.34}", 'http://www.omdbapi.com/')
+    parse_last_response_body = JSON.parse(last_response.body)
+
+    assert_equal parse_last_response_body.key?('Response'), true
+    assert_equal parse_last_response_body.key?('Error'), true
+    assert_equal parse_last_response_body['Error'], 'Movie not found!'
+  end
+
+  def test_passing_an_invalid_page_number_throws_error
+    # This is sending a 200 response. I would probably ask that a differnt code be
+    # sent instead of 200 for an error
+    make_request("?apikey=#{ENV['OMDB_API_KEY']}&s=thomas&page=#{0.34}", 'http://www.omdbapi.com/')
+    parse_last_response_body = JSON.parse(last_response.body)
+
+    assert_equal parse_last_response_body.key?('Response'), true
+    assert_equal parse_last_response_body.key?('Error'), true
+    assert_equal parse_last_response_body['Error'], 'The offset specified in a OFFSET clause may not be negative.'
+  end
+
+  def test_passing_an_invalid_character_in_search_throws_error
+    # This is sending a 200 response. I would probably ask that a differnt code be
+    # sent instead of 200 for an error
+    make_request("?apikey=#{ENV['OMDB_API_KEY']}&s=%&page=1", 'http://www.omdbapi.com/')
+    parse_last_response_body = JSON.parse(last_response.body)
+
+    assert_equal parse_last_response_body.key?('Response'), true
+    assert_equal parse_last_response_body.key?('Error'), true
+    assert_equal parse_last_response_body['Error'], 'Too many results.'
+  end
+
+  def test_passing_an_empty_search_throws_error
+    # This is sending a 200 response. I would probably ask that a differnt code be
+    # sent instead of 200 for an error
+    make_request("?apikey=#{ENV['OMDB_API_KEY']}&s=", 'http://www.omdbapi.com/')
+    parse_last_response_body = JSON.parse(last_response.body)
+
+    assert_equal parse_last_response_body.key?('Response'), true
+    assert_equal parse_last_response_body.key?('Error'), true
+    assert_equal parse_last_response_body['Error'], 'Incorrect IMDb ID.'
+  end
+
+  def test_headers_are_as_expected
+    # This test is a little bit of a reach. there is nothing in acceptacnce criteria about testing headers
+    # or how they should look. I am really testing what is currently there to show
+    # what i would test or ask about
+    make_request("?apikey=#{ENV['OMDB_API_KEY']}&s=thomas", 'http://www.omdbapi.com/')
+
+    assert_equal last_response.headers['content-type'], 'application/json; charset=utf-8'
+    assert_equal last_response.headers['connection'], 'keep-alive'
+    assert_equal last_response.headers['cache-control'], 'public, max-age=86400'
+    assert_equal last_response.headers.key?('expires'), true
+    assert_equal last_response.headers.key?('access-control-allow-origin'), true
+    # Note: from my reading the X-Powered-By header is currently exposed on this API
+    # it is my understanding that this should be hidden from all get responses
+    # exposing an outdated (and possibly vulnerable) version may be an
+    # invitation for people to try and attack it. Current key: "x-powered-by"=>"ASP.NET",
   end
 end

--- a/suite/api_test.rb
+++ b/suite/api_test.rb
@@ -137,6 +137,8 @@ class ApiTest < Minitest::Test
   end
 
   def test_no_search_params_passed_throws_error
+    # This is sending a 200 response. I would probably ask that a differnt code be
+    # sent instead of 200 for an error
     make_request("?apikey=#{ENV['OMDB_API_KEY']}&s=", 'http://www.omdbapi.com/')
     parse_last_response_body = JSON.parse(last_response.body)
 
@@ -172,17 +174,6 @@ class ApiTest < Minitest::Test
     assert_equal parse_last_response_body.key?('Response'), true
     assert_equal parse_last_response_body.key?('Error'), true
     assert_equal parse_last_response_body['Error'], 'The offset specified in a OFFSET clause may not be negative.'
-  end
-
-  def test_passing_an_invalid_character_in_search_throws_error
-    # This is sending a 200 response. I would probably ask that a differnt code be
-    # sent instead of 200 for an error
-    make_request("?apikey=#{ENV['OMDB_API_KEY']}&s=%&page=1", 'http://www.omdbapi.com/')
-    parse_last_response_body = JSON.parse(last_response.body)
-
-    assert_equal parse_last_response_body.key?('Response'), true
-    assert_equal parse_last_response_body.key?('Error'), true
-    assert_equal parse_last_response_body['Error'], 'Too many results.'
   end
 
   def test_passing_an_empty_search_throws_error


### PR DESCRIPTION
- Test IMBDID is uniform for all responses on page one
- Passing nothing but an API key throws an error
- Passing no query params into s= throws error
- Passing incorrect datatypes into s= throws error
- Passing an invalid page number (p=) throws an error
- Total results key exists on a successful response
- Test headers are 'accepted'
